### PR TITLE
On hitting a obstacle on the outer cylinder and restarting the game, …

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -74,6 +74,7 @@ public class PlayerController : MonoBehaviour
         gamePassed = true;
         _analyticsVariables = FindObjectOfType<AnalyticsVariables>();
         pauseGame = FindObjectOfType<PauseGame>();
+        onOuterCylinder = false;
     }
 
     // Update is called once per frame


### PR DESCRIPTION
…the position of the camera and the player is wrong.#79

To fix this, changed the value of onOuterCylinder when on start.